### PR TITLE
fix: getEarthEccentricity() should return the correct result.

### DIFF
--- a/src/lunar/getLunarEclipticPosition.ts
+++ b/src/lunar/getLunarEclipticPosition.ts
@@ -40,7 +40,9 @@ export const getLunarEclipticPosition = (datetime: Date): GeocentricEclipticCoor
 
   const F = convertDegreeToRadian(getLunarArgumentOfLatitude(T))
 
-  const E = convertDegreeToRadian(getEarthEccentricity(T))
+  const E = convertDegreeToRadian(
+    getNormalisedDegree(1 - 0.002516 * T - 0.0000074 * Math.pow(T, 2))
+  )
 
   const A1 = convertDegreeToRadian(getNormalisedDegree(119.75 + 131.849 * T))
 

--- a/src/terra/getEarthEccentricity.ts
+++ b/src/terra/getEarthEccentricity.ts
@@ -4,11 +4,11 @@ import { getNormalisedDegree } from '../'
  *
  * getEarthEccentricity()
  *
- * @see EQ.47.6 p.338 of Meeus, Jean. 1991. Astronomical algorithms. Richmond, Va: Willmann-Bell.
+ * @see EQ.25.4 p.338 of Meeus, Jean. 1991. Astronomical algorithms. Richmond, Va: Willmann-Bell.
  *
  * @param T (of type number) the Ephemeris Time or the number of centuries since J2000 epoch
  * @returns the eccentricity of the Earth's orbit around the Sun
  */
 export const getEarthEccentricity = (T: number): number => {
-  return getNormalisedDegree(1 - 0.002516 * T - 0.0000074 * Math.pow(T, 2))
+  return getNormalisedDegree(0.016708634 - 0.000042037 * T - 0.0000001267 * Math.pow(T, 2))
 }

--- a/src/tests/terra.test.ts
+++ b/src/tests/terra.test.ts
@@ -10,7 +10,7 @@ import {
 // differential w.r.t a time component. We set it to the date provided
 // on p.342 of Meeus, Jean. 1991. Astronomical algorithms.Richmond,
 // Va: Willmann - Bell.:
-export const datetime = new Date('1992-04-12T00:00:00.000+00:00')
+export const datetime = new Date('1992-10-13T00:00:00.000+00:00')
 
 const T = getNumberOfJulianCenturiesSinceEpoch2000(datetime)
 
@@ -22,7 +22,7 @@ suite('@observerly/polaris Terra', () => {
 
     it('getEarthEccentricity should be', () => {
       const E = getEarthEccentricity(T)
-      expect(E).toBeCloseTo(1.000194)
+      expect(E).toBeCloseTo(0.016711668)
     })
   })
 


### PR DESCRIPTION
bugfix: getEarthEccentricity() should return the correct result. 

Includes changes to variable E which is dependent on the eccentricity of the Earth's orbit but isn't equivalent. 

Includes associated test suite changes to terra.test.ts.