### PR TITLE
fix: Typo in precessEquatorialCoordinate().

### DIFF
--- a/src/coordinates/precessEquatorialCoordinate.ts
+++ b/src/coordinates/precessEquatorialCoordinate.ts
@@ -26,7 +26,7 @@ export const precessEquatorialCoordinate = (
   let { ra, dec } = equatorialCoordinate
 
   ra = convertDegreeToRadian(ra)
-  dec = convertDegreeToRadian(ra)
+  dec = convertDegreeToRadian(dec)
 
   const x1 = [Math.cos(dec) * Math.cos(ra), Math.cos(dec) * Math.sin(ra), Math.sin(dec)]
 

--- a/src/tests/coordinate.test.ts
+++ b/src/tests/coordinate.test.ts
@@ -66,7 +66,7 @@ suite('@observerly/polaris Coodinate', () => {
     })
 
     const { ra, dec } = precessEquatorialCoordinate(betelgeuse, datetime.getFullYear(), 1875)
-    expect(ra).toBeCloseTo(86.901619)
-    expect(dec).toBeCloseTo(1.519194)
+    expect(ra).toBeCloseTo(86.81801)
+    expect(dec).toBeCloseTo(7.3759358)
   })
 })


### PR DESCRIPTION
fix: Typo in precessEquatorialCoordinate() where the wrong equatorial coordinate was being converted from degrees to radians.